### PR TITLE
Fix compile error with msvc

### DIFF
--- a/src/shopping_cart.cc
+++ b/src/shopping_cart.cc
@@ -1,4 +1,5 @@
 #include "../include/shopping_cart.h"
+#include <algorithm>
 
 Order ShoppingCart::Checkout() {
     double total_price = 0;


### PR DESCRIPTION
Code line: 30 reference std::transform, but not get <algorithm> header included, which caused compile error on msvc (tested on Visual Studio 2019).